### PR TITLE
Add support for removeAdditional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concord",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "transforms a Typescript interface into usable client / server code",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -12,8 +12,8 @@ export interface ClassValidator {
   [method: string]: Ajv.ValidateFunction;
 }
 
-function createValidator(): Ajv.Ajv {
-  const ajv = new Ajv({ useDefaults: true, allErrors: true });
+function createValidator(removeAdditional: boolean): Ajv.Ajv {
+  const ajv = new Ajv({ useDefaults: true, allErrors: true, removeAdditional });
   ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
   ajv.addKeyword('coerce-date', {
     type: 'string',
@@ -39,7 +39,7 @@ function createValidator(): Ajv.Ajv {
 }
 
 export function createClassValidator(schema: { definitions: any }, className: string, field: string): ClassValidator {
-  const ajv = createValidator();
+  const ajv = createValidator(false);
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);
   }
@@ -48,8 +48,12 @@ export function createClassValidator(schema: { definitions: any }, className: st
   ]));
 }
 
-export function createReturnTypeValidator(schema: { definitions: any }, className: string): ClassValidator {
-  const ajv = createValidator();
+export function createReturnTypeValidator(
+  schema: { definitions: any },
+  className: string,
+  removeAdditional: boolean
+): ClassValidator {
+  const ajv = createValidator(removeAdditional);
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);
   }
@@ -59,9 +63,64 @@ export function createReturnTypeValidator(schema: { definitions: any }, classNam
 }
 
 export function createInterfaceValidator(schema: { definitions: any }, ifaceName: string): Ajv.ValidateFunction {
-  const ajv = createValidator();
+  const ajv = createValidator(false);
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);
   }
   return ajv.compile(schema.definitions[ifaceName]);
+}
+
+export function verifySchemaNestedAnyOf(
+  schema: { [key: string]: any },
+  ctx: string,
+  inRestricted: boolean,
+  root: { [key: string]: any }
+) {
+  // console.log(ctx);
+  if (schema.definitions) {
+    for (const [name, def] of Object.entries(schema.definitions)) {
+      verifySchemaNestedAnyOf(def, ctx + '.' + name, false, root);
+    }
+    return;
+  }
+  if (schema.$ref) {
+    verifySchemaNestedAnyOf(root.definitions[schema.$ref.replace('#/definitions/', '')], ctx, inRestricted, root);
+    return;
+  }
+  if (schema.additionalProperties === false && inRestricted) {
+    throw new Error('Found additionalProperties === false inside anyOf/oneOf: ' + ctx);
+  }
+  if (schema.anyOf) {
+    // heuristic for functions that return object or null
+    // removing additional properties can't break "null"
+    if (schema.anyOf.length === 2 && schema.anyOf.some((entry: any) => entry.type === 'null')) {
+      return;
+    }
+    for (const [idx, item] of schema.anyOf.entries()) {
+      verifySchemaNestedAnyOf(item, ctx + '#anyOf.' + idx, true, root);
+    }
+    return;
+  }
+  if (schema.oneOf) {
+    for (const [idx, item] of schema.oneOf.entries()) {
+      verifySchemaNestedAnyOf(item, ctx + '#oneOf.' + idx, true, root);
+    }
+    return;
+  }
+  if (schema.type === 'object' && schema.properties) {
+    const isMethod = Object.keys(schema.properties).length === 3 &&
+      schema.properties.returns && schema.properties.params && schema.properties.throws;
+    for (const [prop, def] of Object.entries(schema.properties)) {
+      // heuristic for throws (not converted by ajv)
+      if (isMethod && prop === 'throws') {
+        continue;
+      }
+      verifySchemaNestedAnyOf(def, ctx + '.' + prop, false, root);
+    }
+    return;
+  }
+  if (schema.type === 'array') {
+    verifySchemaNestedAnyOf(schema.items, ctx + '.items', false, root);
+    return;
+  }
 }

--- a/templates/ts/client-browser.ts.mustache
+++ b/templates/ts/client-browser.ts.mustache
@@ -15,6 +15,7 @@ export interface Options extends Pick<RequestInit,
   fetchImplementation?: typeof fetch;
   timeoutMs?: number;
   headers?: Record<string, string>;
+  removeAdditional?: boolean;
 }
 
 {{> clientMain }}

--- a/templates/ts/client-imports.ts.mustache
+++ b/templates/ts/client-imports.ts.mustache
@@ -1,4 +1,4 @@
-import { createReturnTypeValidator, ClassValidator, ValidationError } from './common';
+import { createReturnTypeValidator, ClassValidator, ValidationError, verifySchemaNestedAnyOf } from './common';
 import {
   schema,
   InternalServerError,

--- a/templates/ts/client-main.ts.mustache
+++ b/templates/ts/client-main.ts.mustache
@@ -46,14 +46,20 @@ export class {{name}}Client {
     '{{name}}',
     {{/methods}}
   ];
-  public static readonly validators: ClassValidator = createReturnTypeValidator(schema, '{{{name}}}');
+  public static readonly validators: ClassValidator = createReturnTypeValidator(schema, '{{{name}}}', false);
+  public static readonly validatorsRemove: ClassValidator = createReturnTypeValidator(schema, '{{{name}}}', true);
 
   protected readonly props = schema.definitions.{{{name}}}.properties;
 
   public readonly validators: ClassValidator; // We don't have class name in method scope because mustache sux
 
   public constructor(public readonly serverUrl: string, protected readonly options: Options = {}) {
-    this.validators = {{{name}}}Client.validators;
+    if (options.removeAdditional) {
+      verifySchemaNestedAnyOf(schema, '/', false, schema);
+      this.validators = {{{name}}}Client.validatorsRemove;
+    } else {
+      this.validators = {{{name}}}Client.validators;
+    }
   }
   {{#methods}}
 

--- a/templates/ts/client-node.ts.mustache
+++ b/templates/ts/client-node.ts.mustache
@@ -8,6 +8,7 @@ export interface Options extends Pick<RequestInit, 'agent' | 'redirect' | 'follo
   fetchImplementation?: typeof fetch;
   timeoutMs?: number;
   headers?: Record<string, string>;
+  removeAdditional?: boolean;
 }
 
 {{> clientMain }}


### PR DESCRIPTION
Due to the way typescript-json-schema generates schema for union types
the Ajv implementation of removeAdditional will fail validation for
valid inputs - concord will verify the schema for union types and throw
an error if detected.

Allowed cases:
- multiple throws - throws are not coerced by Ajv
- types of the form "T | null" which won't be broken by Ajv