### PR TITLE
Use more specific types for schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "concord",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -469,9 +469,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.130",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.130.tgz",
-      "integrity": "sha512-H++wk0tbneBsRVfLkgAAd0IIpmpVr2Bj4T0HncoOsQf3/xrJexRYQK2Tqo0Ej3pFslM8GkMgdis9bu6xIb1ycw==",
+      "version": "4.14.132",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
+      "integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw==",
       "dev": true
     },
     "@types/minimatch": {
@@ -2158,9 +2158,9 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -6894,9 +6894,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.16.0.tgz",
-      "integrity": "sha512-7hcmbUw+6INffSPBdnO8KSjJRg2bLRoI7EeZMf5MHdV5kpyYMeoMR5w8AIiZbKIhYGwrXlbgvO7gFTsXNHShuQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.17.0.tgz",
+      "integrity": "sha512-3EXZSximCzxuVKpIHtyec8Wm2dWZn1fc5tQi34qWfiUgubEVYHjUvr0GOJojqf3mifI6oyKnCdrGxaOI+lWReA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -8302,9 +8302,9 @@
       }
     },
     "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
+      "integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
       "dev": true,
       "requires": {
         "commander": "^2.19.0",
@@ -8321,18 +8321,19 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz",
-      "integrity": "sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz",
+      "integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
       "dev": true,
       "requires": {
         "cacache": "^11.3.2",
         "find-cache-dir": "^2.0.0",
         "is-wsl": "^1.1.0",
+        "loader-utils": "^1.2.3",
         "schema-utils": "^1.0.0",
         "serialize-javascript": "^1.7.0",
         "source-map": "^0.6.1",
-        "terser": "^3.17.0",
+        "terser": "^4.0.0",
         "webpack-sources": "^1.3.0",
         "worker-farm": "^1.7.0"
       },
@@ -8624,14 +8625,14 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw=="
     },
     "typescript-json-schema": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.38.0.tgz",
-      "integrity": "sha512-X3dnxETu/K4e17CW6ZYnBLVlH3K5RRlDg8RpPKz6YKJrtd0eL9MHi0OWhyQgjtGw0NAKGI5jpoXUsiR+6xPcZw==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.38.1.tgz",
+      "integrity": "sha512-+bm4cqlpWIjdtq5e1bj/gO/j+UQSeFlctdBFiNMQCQzr8v6RK7/Nuk0Jo1cL6LtRRa2YiFYcAncdeTQTyrLH8w==",
       "requires": {
         "glob": "~7.1.4",
         "json-stable-stringify": "^1.0.1",
@@ -9030,9 +9031,9 @@
       }
     },
     "webpack": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.0.tgz",
-      "integrity": "sha512-ofFq9jjAn4HRzlmkcZZrjijbRZcqDw+mM9KrjKd0r6lS0qxyZ7jzICzhphGafXL62dGdjP7TgMK9mZeMLUgZgw==",
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.32.2.tgz",
+      "integrity": "sha512-F+H2Aa1TprTQrpodRAWUMJn7A8MgDx82yQiNvYMaj3d1nv3HetKU0oqEulL9huj8enirKi8KvEXQ3QtuHF89Zg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concord",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "transforms a Typescript interface into usable client / server code",
   "main": "dist/index.js",
   "scripts": {
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/glob": "^7.1.1",
-    "@types/lodash": "^4.14.130",
+    "@types/lodash": "^4.14.132",
     "@types/mustache": "^0.8.32",
     "@types/mz": "0.0.32",
     "@types/node": "^10.0.0",
@@ -45,9 +45,9 @@
     "ava": "^1.4.1",
     "binaris": "^6.7.0",
     "chai": "^4.2.0",
-    "puppeteer": "^1.16.0",
+    "puppeteer": "^1.17.0",
     "tslint": "^5.16.0",
-    "webpack": "^4.32.0",
+    "webpack": "^4.32.2",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.4.1"
   },
@@ -58,8 +58,8 @@
     "mz": "^2.7.0",
     "rmfr": "^2.0.0",
     "toposort": "^2.0.2",
-    "typescript": "^3.4.5",
-    "typescript-json-schema": "^0.38.0",
+    "typescript": "^3.5.1",
+    "typescript-json-schema": "^0.38.1",
     "yargs": "^13.2.4"
   }
 }

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -39,7 +39,11 @@ function createValidator(): Ajv {
   return ajv;
 }
 
-export function createClassValidator(schema: { definitions: any }, className: string, field: string): ClassValidator {
+export function createClassValidator(
+  schema: { definitions: { [key: string]: any } },
+  className: string,
+  field: string
+): ClassValidator {
   const ajv = createValidator();
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);
@@ -49,7 +53,10 @@ export function createClassValidator(schema: { definitions: any }, className: st
   ]));
 }
 
-export function createReturnTypeValidator(schema: { definitions: any }, className: string): ClassValidator {
+export function createReturnTypeValidator(
+  schema: { definitions: { [key: string]: any } },
+  className: string
+): ClassValidator {
   const ajv = createValidator();
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);
@@ -59,7 +66,10 @@ export function createReturnTypeValidator(schema: { definitions: any }, classNam
   ]));
 }
 
-export function createInterfaceValidator(schema: { definitions: any }, ifaceName: string): ValidateFunction {
+export function createInterfaceValidator(
+  schema: { definitions: { [key: string]: any } },
+  ifaceName: string
+): ValidateFunction {
   const ajv = createValidator();
   for (const [k, v] of Object.entries(schema.definitions)) {
     ajv.addSchema(v, `#/definitions/${k}`);


### PR DESCRIPTION
TypeScript 3.5 becomes more strict with generic type parameters
implicitly constrained to unknown with Object.entries behaving as if any
is { [key: string]: unknown }